### PR TITLE
Security cleanup for `set-env` usage

### DIFF
--- a/.github/workflows/weekly-1on1.yml
+++ b/.github/workflows/weekly-1on1.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set Date
-        run: echo "::set-env name=DATE::$(date -u '+%F')"
+        run: echo "DATE=$(date -u '+%F')" >> $GITHUB_ENV
       
       - name: weekly-1-on-1-issue-management
         uses: imjohnbo/issue-bot@v2.2

--- a/.github/workflows/weekly-journal-issue.yml
+++ b/.github/workflows/weekly-journal-issue.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set Date
-        run: echo "::set-env name=DATE::$(date -u '+%F')"
+        run: echo "DATE=$(date -u '+%F')" >> $GITHUB_ENV
       
       - name: weekly-journal-issue-management
         uses: imjohnbo/issue-bot@v2.2


### PR DESCRIPTION
New usage patterns now in use per https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files